### PR TITLE
Fixed Trail screen active marker resetting to index 0 inexplicably

### DIFF
--- a/src/components/shared/MapWithListView.js
+++ b/src/components/shared/MapWithListView.js
@@ -268,13 +268,16 @@ export default class MapWithListView extends Component {
 
     const { items } = this.props;
     this.state = {
+      isInitialized: false,
       activeMarker: items[0],
       markersFocused: false,
     };
   }
 
   componentWillReceiveProps({ items }) {
-    this.setState({ activeMarker: items[0] });
+    if (!this.state.isInitialized) {
+      this.setState({ isInitialized: true, activeMarker: items[0] });
+    }
   }
 
   focusMarkers(markers) {


### PR DESCRIPTION
Having the active marker being set in componentWillReceiveProps creates scenarios where the active marker is set to the first entry at seemingly random times (for example, sometimes when going back from a trail entry).

I'm assuming that this setting of active marker is done in componentWIllReceiveProps due to it being set too early (the map not being ready, perhaps?) if it's done anywhere else. From my experiments it doesn't seem to work from being set in onMapReady, the constructor or any of the mounting lifecycle events.

This pull request aims to solve this by still resetting in componentWillReceiveProps but only doing it the first time it happens.