### PR TITLE
Hack to stop audio when exiting object views that come from trails

### DIFF
--- a/src/components/screens/ObjectDetailsScreen.js
+++ b/src/components/screens/ObjectDetailsScreen.js
@@ -110,6 +110,7 @@ class ObjectDetailsScreen extends Component {
       internet: this.props.internet,
       audioBtnDisabled: false,
       videoBtnDisabled: false,
+      isTrail: params.isTrail,
     };
 
     this.mediaService = MediaService.getInstance();
@@ -136,6 +137,7 @@ class ObjectDetailsScreen extends Component {
   }
 
   componentWillUnmount() {
+    if (this.state.isTrail === true) { this.mediaService.release(); }
     this.stopListenIngToAudioEvents();
   }
 

--- a/src/components/screens/TrailScreen.js
+++ b/src/components/screens/TrailScreen.js
@@ -137,6 +137,7 @@ class TrailScreen extends Component {
         items={trailObjects}
         initialLocation={trailItem.location}
         navigation={navigation}
+        isTrail
       />,
       this.renderMapInformationOverlay(),
       ]

--- a/src/components/shared/MapWithListView.js
+++ b/src/components/shared/MapWithListView.js
@@ -386,8 +386,9 @@ export default class MapWithListView extends Component {
       default:
       {
         const { title, id } = contentObject;
+        const isTrail = this.props.isTrail === true;
         AnalyticsUtils.logEvent("view_object", { id, name: title });
-        navigate("ObjectDetailsScreen", { title, contentObject });
+        navigate("ObjectDetailsScreen", { title, contentObject, isTrail });
       }
     }
   }


### PR DESCRIPTION
This solves the broken audio when exiting a trail object with audio playing.