### PR TITLE
Feature/slynga order fix

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,13 +99,13 @@ keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '25.0.3'
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         applicationId "com.guidehbg"
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 10
+        versionCode 13
         versionName "1.2"
         ndk {
             abiFilters "armeabi-v7a", "x86"

--- a/src/components/screens/GuideListScreen.js
+++ b/src/components/screens/GuideListScreen.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import {
   ActivityIndicator,
+  Platform,
   Dimensions,
   Image,
   StyleSheet,
@@ -24,6 +25,8 @@ import GuideList from "../shared/GuideList";
 import MapWithListView from "../shared/MapWithListView";
 
 const screenWidth = Dimensions.get("window").width;
+
+const ios = Platform.OS === "ios";
 
 const settingsIcon = require("../../images/settings.png");
 const mapIcon = require("../../images/iconLocation.png");
@@ -157,7 +160,6 @@ class GuideListScreen extends Component {
     };
   }
 
-
   componentDidMount() {
     this.props.navigation.setParams({ toggleMap: this.toggleMap, showMap: this.state.showMap });
   }
@@ -177,10 +179,10 @@ class GuideListScreen extends Component {
   }
 
   componentWillUnmount() {
+    const index = 0;
     const routes = [];
-    this.setState({ routes });
+    this.setState({ index, routes });
   }
-
 
   toggleMap = () => {
     const showMap = !this.state.showMap;
@@ -207,16 +209,19 @@ class GuideListScreen extends Component {
 
   _renderScene = ({ route }) => {
     // If we're still fetching, show the activity indicator instead
-    const { isFetching } = this.props;
-    if (isFetching) {
-      return (
-        <View style={styles.loadingContainer}>
-          <ActivityIndicator />
-        </View>
-      );
+    if (ios) {
+      const { isFetching } = this.props;
+      if (isFetching) {
+        return (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator />
+          </View>
+        );
+      }
     }
 
     const { showMap, index, routes } = this.state;
+
     if (Math.abs(index - routes.indexOf(route)) > 2) {
       // Do not render pages that are to far away from the current page
       return null;
@@ -230,17 +235,17 @@ class GuideListScreen extends Component {
     categoryType.items.forEach((element) => {
       switch (element.type) {
         case "guide":
-          {
-            const result = guides.find(guide => guide.id === element.id);
-            if (result) items.push(result);
-            break;
-          }
+        {
+          const result = guides.find(guide => guide.id === element.id);
+          if (result) items.push(result);
+          break;
+        }
         case "guidegroup":
-          {
-            const loc = locations.find(l => l.id === element.id);
-            if (loc) items.push(loc);
-            break;
-          }
+        {
+          const loc = locations.find(l => l.id === element.id);
+          if (loc) items.push(loc);
+          break;
+        }
         default:
       }
     });
@@ -264,7 +269,6 @@ class GuideListScreen extends Component {
       return (<MapWithListView items={mapItems} navigation={navigation} />);
     }
 
-
     if (currentLocation) {
       // calculate distances from current location
       const { coords } = currentLocation;
@@ -278,7 +282,8 @@ class GuideListScreen extends Component {
   }
 
   render() {
-    const { routes, index } = this.state;
+    const { routes } = this.state;
+
     if (routes.length < 2) {
       return (
         <View>
@@ -289,13 +294,23 @@ class GuideListScreen extends Component {
       );
     }
 
+    if (!ios) {
+      const { isFetching } = this.props;
+      if (isFetching) {
+        return (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator />
+          </View>
+        );
+      }
+    }
+
     return (
       <TabViewAnimated
-        swipeEnabled={false}
         style={styles.container}
         navigationState={this.state}
-        renderScene={this._renderScene}
         renderHeader={this._renderHeader}
+        renderScene={this._renderScene}
         onIndexChange={this._handleIndexChange}
         initialLayout={initialLayout}
       />

--- a/src/components/shared/MapWithListView.js
+++ b/src/components/shared/MapWithListView.js
@@ -252,10 +252,21 @@ export default class MapWithListView extends Component {
         imageUrl: contentObject.image[0].sizes.medium,
         thumbnailUrl: contentObject.image[0].sizes.thumbnail,
         streetAdress: locationObject.street_address,
+        order: contentObject.order,
+        labelDisplayNumber: 0,
         contentObject,
         imageType: (screen === "trailScreen") ? "trailScreen" : contentType,
       });
     });
+
+    trailObjects.sort(function(a,b) { return parseFloat(a.order) - parseFloat(b.order) });
+    
+    var index = 1;
+    trailObjects.forEach((item) => {
+      item.labelDisplayNumber = index;
+      index++;
+   });
+
     return trailObjects;
   }
 
@@ -422,12 +433,12 @@ export default class MapWithListView extends Component {
    * RENDER FUNCTIONS
    */
 
-  numberedMapViewMarker = (trailObject) => {
+  numberedMapViewMarker = (trailObject, c) => {
     const { id, location } = trailObject;
     const { activeMarker } = this.state;
 
     const image = this.markerImageForTrailObject(trailObject);
-    const numberString = trailObject.contentObject.order + 1;
+    const numberString = trailObject.labelDisplayNumber;
     const active = activeMarker.id === trailObject.id;
 
     return (
@@ -496,7 +507,7 @@ export default class MapWithListView extends Component {
     const trailScreen = item.imageType === "trailScreen";
     if (!trailScreen) return null;
 
-    const numberString = item.contentObject.order + 1;
+    const numberString = item.labelDisplayNumber;
     const numberView = (
       <View style={styles.listImageNumberView}>
         <Text style={styles.listImageNumberText}>{numberString}</Text>

--- a/src/components/shared/MapWithListView.js
+++ b/src/components/shared/MapWithListView.js
@@ -433,7 +433,7 @@ export default class MapWithListView extends Component {
    * RENDER FUNCTIONS
    */
 
-  numberedMapViewMarker = (trailObject, c) => {
+  numberedMapViewMarker = (trailObject) => {
     const { id, location } = trailObject;
     const { activeMarker } = this.state;
 

--- a/src/components/shared/MapWithListView.js
+++ b/src/components/shared/MapWithListView.js
@@ -259,13 +259,13 @@ export default class MapWithListView extends Component {
       });
     });
 
-    trailObjects.sort(function(a,b) { return parseFloat(a.order) - parseFloat(b.order) });
-    
-    var index = 1;
+    trailObjects.sort((a, b) => parseFloat(a.order) - parseFloat(b.order));
+
+    let index = 1;
     trailObjects.forEach((item) => {
       item.labelDisplayNumber = index;
       index++;
-   });
+    });
 
     return trailObjects;
   }

--- a/src/components/shared/VideoPlayer.js
+++ b/src/components/shared/VideoPlayer.js
@@ -219,10 +219,6 @@ export default class VideoPlayer extends Component {
             />
             <Text style={styles.duration}>{timeHelper.toTimeMarker(this.state.duration)}</Text>
           </View>
-
-          <TouchableOpacity style={styles.button} onPress={this.toggleFullscreen}>
-            <Icon name={isAndroidFullscreen ? "fullscreen-exit" : "fullscreen"} size={ICON_SIZE} style={styles.buttonIcon} />
-          </TouchableOpacity>
         </View>
       </ViewContainer>
     );


### PR DESCRIPTION
I know the "item.labelDisplayNumber = index" is a bit weird, but using the order for labeling could cause issues with the numbers "skipping" if any of the elements are set to "not visible" in the back end.