### PR TITLE
Swiping last element in map view should not switch tabs.

### DIFF
--- a/src/components/screens/GuideListScreen.js
+++ b/src/components/screens/GuideListScreen.js
@@ -229,7 +229,6 @@ class GuideListScreen extends Component {
       renderLabel={this._renderTabBarLabel}
       indicatorStyle={styles.tabBarIndicator}
       tabStyle={styles.tabStyle}
-      scrollEnabled
       {...props}
     />)
 
@@ -352,6 +351,7 @@ class GuideListScreen extends Component {
         renderScene={this._renderScene}
         onIndexChange={this._handleIndexChange}
         initialLayout={initialLayout}
+        swipeEnabled={!this.state.showMap}
       />
     );
   }


### PR DESCRIPTION
So we disable it when the map is shown.