### PR TITLE
don't crash on audio file switching

### DIFF
--- a/src/services/mediaService.js
+++ b/src/services/mediaService.js
@@ -230,7 +230,7 @@ export default class MediaService {
     this.onAudioLoadSuccessCallback = onAudioLoadSuccess;
     this.onAudioUpdateCallback = onAudioUpdate;
 
-    if (hasAudio) this.mediaService.release();
+    if (hasAudio) this.release();
     const audioName = audioState.title;
     console.log(`load ${audioName}`);
 


### PR DESCRIPTION
was referencing the wrong object when releasing before new play