### PR TITLE
Navigation from DownloadScreen

### DIFF
--- a/src/components/screens/DownloadsScreen.js
+++ b/src/components/screens/DownloadsScreen.js
@@ -10,7 +10,7 @@ import {
   pauseDownloadGuide,
   resumeDownloadGuide,
 } from "../../actions/downloadGuidesActions";
-import { selectCurrentGuide } from "../../actions/uiStateActions";
+import { selectCurrentGuide, showBottomBar } from "../../actions/uiStateActions";
 import { AnalyticsUtils } from "../../utils";
 
 const styles = StyleSheet.create({
@@ -22,6 +22,7 @@ const styles = StyleSheet.create({
 type Props = {
   downloads: OfflineGuide[],
   cancelDownload(guide: Guide): void,
+  hideBottomBar(): void,
   pauseDownload(guide: Guide): void,
   resumeDownload(guide: Guide): void,
   selectGuide(guide: Guide): void,
@@ -43,11 +44,13 @@ class DownloadsScreen extends Component<Props> {
     this.props.selectGuide(guide);
 
     if (guideType === "guide") {
+      this.props.hideBottomBar();
       AnalyticsUtils.logEvent("view_guide", { name: guide.slug });
-      this.props.navigation.navigate("GuideDetailsScreen", { title: guide.name });
+      this.props.navigation.navigate("GuideDetailsScreen", { title: guide.name, bottomBarOnUnmount: true });
     } else if (guideType === "trail") {
+      this.props.hideBottomBar();
       AnalyticsUtils.logEvent("view_guide", { name: guide.slug });
-      this.props.navigation.navigate("TrailScreen", { title: guide.name });
+      this.props.navigation.navigate("TrailScreen", { title: guide.name, bottomBarOnUnmount: true });
     }
   }
 
@@ -89,6 +92,7 @@ function mapDispatchToProps(dispatch) {
     pauseDownload: (guide: Guide) => dispatch(pauseDownloadGuide(guide)),
     resumeDownload: (guide: Guide) => dispatch(resumeDownloadGuide(guide)),
     selectGuide: guide => dispatch(selectCurrentGuide(guide)),
+    hideBottomBar: () => dispatch(showBottomBar(false)),
   };
 }
 

--- a/src/components/screens/DownloadsScreen.js
+++ b/src/components/screens/DownloadsScreen.js
@@ -10,6 +10,8 @@ import {
   pauseDownloadGuide,
   resumeDownloadGuide,
 } from "../../actions/downloadGuidesActions";
+import { selectCurrentGuide } from "../../actions/uiStateActions";
+import { AnalyticsUtils } from "../../utils";
 
 const styles = StyleSheet.create({
   mainContainer: {
@@ -21,7 +23,9 @@ type Props = {
   downloads: OfflineGuide[],
   cancelDownload(guide: Guide): void,
   pauseDownload(guide: Guide): void,
-  resumeDownload(guide: Guide): void
+  resumeDownload(guide: Guide): void,
+  selectGuide(guide: Guide): void,
+  navigation: any,
 };
 
 class DownloadsScreen extends Component<Props> {
@@ -33,6 +37,20 @@ class DownloadsScreen extends Component<Props> {
     };
   };
 
+  navigateToGuide = (offlineGuide: OfflineGuide): void => {
+    const { guide } = offlineGuide;
+    const { guideType } = guide;
+    this.props.selectGuide(guide);
+
+    if (guideType === "guide") {
+      AnalyticsUtils.logEvent("view_guide", { name: guide.slug });
+      this.props.navigation.navigate("GuideDetailsScreen", { title: guide.name });
+    } else if (guideType === "trail") {
+      AnalyticsUtils.logEvent("view_guide", { name: guide.slug });
+      this.props.navigation.navigate("TrailScreen", { title: guide.name });
+    }
+  }
+
   renderItem = ({ item }) => (
     <DownloadItemView
       title={item.guide.name}
@@ -42,8 +60,9 @@ class DownloadsScreen extends Component<Props> {
       onPausePress={() => this.props.pauseDownload(item.guide)}
       onResumePress={() => this.props.resumeDownload(item.guide)}
       onClearPress={() => this.props.cancelDownload(item.guide)}
+      onPressItem={() => this.navigateToGuide(item)}
     />
-  );
+  )
 
   render() {
     return (
@@ -69,6 +88,7 @@ function mapDispatchToProps(dispatch) {
     cancelDownload: (guide: Guide) => dispatch(cancelDownloadGuide(guide)),
     pauseDownload: (guide: Guide) => dispatch(pauseDownloadGuide(guide)),
     resumeDownload: (guide: Guide) => dispatch(resumeDownloadGuide(guide)),
+    selectGuide: guide => dispatch(selectCurrentGuide(guide)),
   };
 }
 

--- a/src/components/shared/DownloadItemView.js
+++ b/src/components/shared/DownloadItemView.js
@@ -103,7 +103,9 @@ export default class DownloadItemView extends Component {
         </View>
         <View style={styles.mainContainer}>
           <View style={styles.avatarContainer}>
-            <RoundedThumbnail imageSource={{ uri: this.props.thumbnail }} />
+            <TouchableOpacity onPress={this.props.onPressItem}>
+              <RoundedThumbnail imageSource={{ uri: this.props.thumbnail }} />
+            </TouchableOpacity>
           </View>
           <View style={styles.progressBarContainer}>
             <View style={styles.progressTextContainer}>


### PR DESCRIPTION
Possible to navigate to offline guides by clicking them in the Download Screen.

Gabriel, please verify when this one is in:
https://github.com/helsingborg-stad/app-helsingborg-guide/pull/168