### PR TITLE
Make list in CategoryListScreen cover whole screen

### DIFF
--- a/src/components/screens/CategoryListScreen/styles.js
+++ b/src/components/screens/CategoryListScreen/styles.js
@@ -5,6 +5,7 @@ export default StyleSheet.create({
   container: {
     padding: "4%",
     backgroundColor: Colors.white,
+    height: "100%",
   },
   footer: {
     paddingVertical: 10,


### PR DESCRIPTION
Removes the gray area at the bottom of the screen in category list and makes sure the map button always stays at the bottom.

https://trello.com/c/0V5W21n0/319-fix-list-background-in-category-list