### PR TITLE
Back arrow fix

### DIFF
--- a/guide-app/src/components/screens/CategoryListScreen/index.js
+++ b/guide-app/src/components/screens/CategoryListScreen/index.js
@@ -9,6 +9,7 @@ import {
   selectCurrentCategory,
   showBottomBar
 } from "@actions/uiStateActions";
+import HeaderBackButton from "@shared-components/HeaderBackButton";
 import NavigationListItem from "@shared-components/NavigationListItem";
 import { compareDistance } from "@utils/SortingUtils";
 import { AnalyticsUtils } from "@utils";
@@ -34,7 +35,8 @@ class CategoryListScreen extends Component<Props> {
     return {
       ...HeaderStyles.noElevation,
       title,
-      headerRight: <View />
+      headerRight: <View />,
+      headerLeft: <HeaderBackButton navigation={navigation} />
     };
   };
 

--- a/guide-app/src/components/screens/CategoryListScreen/index.js
+++ b/guide-app/src/components/screens/CategoryListScreen/index.js
@@ -31,10 +31,11 @@ class CategoryListScreen extends Component<Props> {
     if (params) {
       ({ title } = params);
     }
-    return Object.assign(HeaderStyles.noElevation, {
+    return {
+      ...HeaderStyles.noElevation,
       title,
       headerRight: <View />
-    });
+    };
   };
 
   constructor(props: Props) {

--- a/guide-app/src/components/screens/CategoryMapScreen/index.js
+++ b/guide-app/src/components/screens/CategoryMapScreen/index.js
@@ -28,10 +28,11 @@ class CategoryMapScreen extends Component<Props> {
     if (params) {
       ({ title } = params);
     }
-    return Object.assign(HeaderStyles.noElevation, {
+    return {
+      ...HeaderStyles.noElevation,
       title,
       headerRight: <View />
-    });
+    };
   };
 
   constructor(props: Props) {
@@ -135,7 +136,4 @@ function mapDispatchToProps(dispatch: Dispatch) {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(CategoryMapScreen);
+export default connect(mapStateToProps, mapDispatchToProps)(CategoryMapScreen);

--- a/guide-app/src/components/screens/DownloadsScreen.js
+++ b/guide-app/src/components/screens/DownloadsScreen.js
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import { FlatList, StyleSheet } from "react-native";
 import { connect } from "react-redux";
 import DownloadItemView from "@shared-components/DownloadItemView";
+import HeaderBackButton from "@shared-components/HeaderBackButton";
 import LangService from "@services/langService";
 import { Colors } from "@assets/styles";
 import {
@@ -30,11 +31,12 @@ type Props = {
 };
 
 class DownloadsScreen extends Component<Props> {
-  static navigationOptions = () => {
+  static navigationOptions = ({ navigation }) => {
     const title = LangService.strings.OFFLINE_CONTENT;
     return {
       title,
-      headerRight: null
+      headerRight: null,
+      headerLeft: <HeaderBackButton navigation={navigation} />
     };
   };
 
@@ -102,7 +104,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(DownloadsScreen);
+export default connect(mapStateToProps, mapDispatchToProps)(DownloadsScreen);

--- a/guide-app/src/components/screens/GuideScreen.js
+++ b/guide-app/src/components/screens/GuideScreen.js
@@ -6,6 +6,7 @@ import { connect } from "react-redux";
 
 import GuideView from "@shared-components/GuideView";
 import { AnalyticsUtils } from "@utils";
+import HeaderBackButton from "@shared-components/HeaderBackButton";
 import SearchButton from "@src/components/header/SearchButton";
 import {
   selectCurrentContentObject,
@@ -28,7 +29,8 @@ class GuideScreen extends Component<Props> {
       const { title } = params;
       return {
         title,
-        headerRight: <SearchButton navigation={navigation} />
+        headerRight: <SearchButton navigation={navigation} />,
+        headerLeft: <HeaderBackButton navigation={navigation} />
       };
     }
     return {};
@@ -87,7 +89,4 @@ function mapDispatchToProps(dispatch: Dispatch) {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(GuideScreen);
+export default connect(mapStateToProps, mapDispatchToProps)(GuideScreen);

--- a/guide-app/src/components/screens/HomeScreen/index.js
+++ b/guide-app/src/components/screens/HomeScreen/index.js
@@ -35,9 +35,10 @@ type Props = {
 class HomeScreen extends Component<Props> {
   static navigationOptions = () => {
     const title = LangService.strings.APP_NAME;
-    return Object.assign(HeaderStyles.noElevation, {
+    return {
+      ...HeaderStyles.noElevation,
       title
-    });
+    };
   };
 
   componentDidMount() {
@@ -203,7 +204,4 @@ function mapDispatchToProps(dispatch: Dispatch) {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(HomeScreen);
+export default connect(mapStateToProps, mapDispatchToProps)(HomeScreen);

--- a/guide-app/src/components/screens/LocationScreen.js
+++ b/guide-app/src/components/screens/LocationScreen.js
@@ -21,10 +21,11 @@ type Props = {
 class LocationScreen extends Component<Props> {
   static navigationOptions = ({ navigation }) => {
     const { title } = navigation.state.params;
-    return Object.assign(HeaderStyles.noElevation, {
+    return {
+      ...HeaderStyles.noElevation,
       title,
       headerRight: <View />
-    });
+    };
   };
 
   componentWillUnmount() {
@@ -99,7 +100,4 @@ function mapDispatchToProps(dispatch: Dispatch) {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(LocationScreen);
+export default connect(mapStateToProps, mapDispatchToProps)(LocationScreen);

--- a/guide-app/src/components/screens/LocationScreen.js
+++ b/guide-app/src/components/screens/LocationScreen.js
@@ -3,6 +3,7 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { View } from "react-native";
+import HeaderBackButton from "@shared-components/HeaderBackButton";
 import LocationView from "@shared-components/LocationView";
 import { AnalyticsUtils } from "@utils";
 import { HeaderStyles } from "@assets/styles";
@@ -24,7 +25,8 @@ class LocationScreen extends Component<Props> {
     return {
       ...HeaderStyles.noElevation,
       title,
-      headerRight: <View />
+      headerRight: <View />,
+      headerLeft: <HeaderBackButton navigation={navigation} />
     };
   };
 

--- a/guide-app/src/components/screens/ObjectScreen.js
+++ b/guide-app/src/components/screens/ObjectScreen.js
@@ -51,9 +51,10 @@ function isMediaAvailable(media?: MediaContent): boolean {
 class ObjectScreen extends Component<Props> {
   static navigationOptions = ({ navigation }) => {
     const { title } = navigation.state.params;
-    return Object.assign(HeaderStyles.noElevation, {
+    return {
+      ...HeaderStyles.noElevation,
       title
-    });
+    };
   };
 
   onSwiperIndexChanged = (newIndex: number) => {
@@ -177,7 +178,4 @@ function mapDispatchToProps(dispatch: Dispatch) {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ObjectScreen);
+export default connect(mapStateToProps, mapDispatchToProps)(ObjectScreen);

--- a/guide-app/src/components/screens/ObjectScreen.js
+++ b/guide-app/src/components/screens/ObjectScreen.js
@@ -2,6 +2,7 @@
 
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import HeaderBackButton from "@shared-components/HeaderBackButton";
 import ObjectView from "@shared-components/ObjectView";
 import { AnalyticsUtils } from "@utils";
 import LangService from "@services/langService";
@@ -53,7 +54,8 @@ class ObjectScreen extends Component<Props> {
     const { title } = navigation.state.params;
     return {
       ...HeaderStyles.noElevation,
-      title
+      title,
+      headerLeft: <HeaderBackButton navigation={navigation} />
     };
   };
 

--- a/guide-app/src/components/screens/TrailScreen.js
+++ b/guide-app/src/components/screens/TrailScreen.js
@@ -6,6 +6,7 @@ import { connect } from "react-redux";
 
 import { AnalyticsUtils } from "@utils";
 import InfoOverlayToggleView from "@shared-components/InfoOverlayToggleView";
+import HeaderBackButton from "@shared-components/HeaderBackButton";
 import TrailView from "@shared-components/TrailView";
 import { releaseAudioFile } from "@actions/audioActions";
 import { showBottomBar } from "@actions/uiStateActions";
@@ -30,11 +31,13 @@ class TrailScreen extends Component<Props, State> {
       ({ title } = params);
       ({ toggleInfoOverlay } = params);
     }
+
     return {
       title,
       headerRight: (
         <InfoOverlayToggleView onToggleInfoOverlay={toggleInfoOverlay} />
-      )
+      ),
+      headerLeft: <HeaderBackButton navigation={navigation} />
     };
   };
 
@@ -100,7 +103,4 @@ function mapDispatchToProps(dispatch: Dispatch) {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TrailScreen);
+export default connect(mapStateToProps, mapDispatchToProps)(TrailScreen);

--- a/guide-app/src/components/shared/HeaderBackButton.js
+++ b/guide-app/src/components/shared/HeaderBackButton.js
@@ -1,0 +1,23 @@
+// @flow
+import React from "react";
+import Icon from "react-native-vector-icons/Entypo";
+import Colors from "@assets/styles/Colors";
+
+const styles = {
+  opacity: 0.6
+};
+function HeaderBackButton({ navigation }: { navigation: Object }) {
+  return (
+    <Icon
+      name={"chevron-left"}
+      size={36}
+      color={Colors.white}
+      style={styles}
+      onPress={() => {
+        navigation.goBack();
+      }}
+    />
+  );
+}
+
+export default HeaderBackButton;


### PR DESCRIPTION
The back button png won't load on iOS in release mode, for some reason. Not sure if it's a bug in `react-navigation`/`react-navigation/stack` or something to do with monorepo and asset loading but investigation did not yield any results so for now we'll use this work around.

Also fixed a "bug" where `HeaderStyles.noElevation` was being mutated.