### PR TITLE
Fix wrong android app id for Lund app

### DIFF
--- a/cities/Lund/android/app/build.gradle
+++ b/cities/Lund/android/app/build.gradle
@@ -132,7 +132,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.ustwo.lund"
+        applicationId "com.lund"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1


### PR DESCRIPTION
The Android app id for the Lund app was wrong, causing builds to fail.